### PR TITLE
Add system design README documentation

### DIFF
--- a/src/main/java/systemdesign/bookmyshow/README.md
+++ b/src/main/java/systemdesign/bookmyshow/README.md
@@ -1,0 +1,33 @@
+# BookMyShow
+
+## Overview
+A minimal booking service that reserves seats for a movie show. It models movies, shows and seats with basic in-memory classes.
+
+## Why this design
+The example focuses on illustrating seat reservation logic without external dependencies. A simple list of seats is sufficient for demonstration.
+
+## Pros
+- Easy to understand and run.
+- Encapsulates booking logic in a service class.
+
+## Cons
+- No persistence or concurrency handling.
+- Seat search is linear and inefficient for large shows.
+
+## Possible improvements
+- Use a database to store shows and bookings.
+- Introduce locking to avoid double booking.
+- Support seat categories and pricing.
+
+## Patterns and principles
+- Separates concerns using a small `BookingService`.
+- Uses domain objects (`Movie`, `Show`, `Seat`).
+
+## High-level design
+Clients interact with `BookingService` to book a seat for a given `Show`. The service iterates over available seats and marks one as booked.
+
+## Low-level design
+- `Movie` holds movie metadata.
+- `Show` aggregates `Seat` objects for a movie.
+- `Seat` maintains its booking state.
+- `BookingService` performs the booking operation.

--- a/src/main/java/systemdesign/fooddelivery/README.md
+++ b/src/main/java/systemdesign/fooddelivery/README.md
@@ -1,0 +1,32 @@
+# Food Delivery
+
+## Overview
+A simple representation of a food ordering system. An order references a restaurant and an item, and the `DeliveryService` prints dispatch information.
+
+## Why this design
+The goal is to demonstrate very basic interactions between restaurant, order and delivery components without modelling real world complexity.
+
+## Pros
+- Minimal code for quick understanding.
+- Clear separation between domain objects and service.
+
+## Cons
+- No concept of delivery personnel or tracking.
+- Orders are not persisted.
+
+## Possible improvements
+- Maintain order status and assignment to delivery agents.
+- Add menu management and pricing.
+- Persist restaurants and orders in a database.
+
+## Patterns and principles
+- Encapsulates delivery logic in a `DeliveryService`.
+- Uses simple domain models (`Restaurant`, `Order`).
+
+## High-level design
+The user creates an `Order` for a `Restaurant` and passes it to `DeliveryService.dispatch`, which currently just prints a message.
+
+## Low-level design
+- `Restaurant` holds the restaurant name.
+- `Order` references a `Restaurant` and an item to be delivered.
+- `DeliveryService` handles dispatching of the order.

--- a/src/main/java/systemdesign/logsystem/README.md
+++ b/src/main/java/systemdesign/logsystem/README.md
@@ -1,0 +1,31 @@
+# Log System
+
+## Overview
+Implements a basic logging service with an in-memory repository. The service accepts log messages and stores them through the repository.
+
+## Why this design
+A repository abstraction keeps storage concerns separate from the service that creates log entries. This example keeps everything in memory for simplicity.
+
+## Pros
+- Straightforward repository-service structure.
+- Easy to replace the repository with another implementation.
+
+## Cons
+- Logs are lost when the process ends.
+- No asynchronous or batched writes.
+
+## Possible improvements
+- Persist logs to disk or an external system.
+- Support log levels and filtering before storage.
+- Make logging asynchronous to avoid blocking callers.
+
+## Patterns and principles
+- Applies the Repository pattern to decouple storage from business logic.
+
+## High-level design
+`LogService` receives log requests and delegates persistence to `LogRepository`, which stores `LogMessage` objects in a list.
+
+## Low-level design
+- `LogMessage` holds level and text.
+- `LogRepository` manages the list of messages.
+- `LogService` offers the `log` operation to clients.

--- a/src/main/java/systemdesign/lrucache/README.md
+++ b/src/main/java/systemdesign/lrucache/README.md
@@ -1,0 +1,30 @@
+# LRU Cache
+
+## Overview
+This module demonstrates a simple Least Recently Used (LRU) cache implemented with a hashmap and a doubly linked list.
+
+## Why this design
+An LRU cache keeps recently accessed items in memory while evicting the least recently used ones. Using a hashmap for O(1) lookups and a linked list for ordering provides efficient access and eviction.
+
+## Pros
+- Constant time `get` and `put` operations.
+- Simple to understand and extend.
+
+## Cons
+- Not thread‑safe.
+- Each entry requires extra memory for list pointers.
+
+## Possible improvements
+- Add synchronization to make the cache concurrent.
+- Allow configurable eviction policies.
+- Persist entries to disk if needed.
+
+## Patterns and principles
+- Combines a hashmap with a doubly linked list to implement the LRU caching pattern.
+
+## High-level design
+Clients call `LruCache` which stores key/value pairs and maintains a usage order list. When capacity is exceeded, the tail node is removed.
+
+## Low-level design
+- `LruCache` manages the hashmap and linked list.
+- `Node` represents each cached entry with `prev` and `next` pointers.

--- a/src/main/java/systemdesign/messaging/README.md
+++ b/src/main/java/systemdesign/messaging/README.md
@@ -1,0 +1,31 @@
+# Messaging Service
+
+## Overview
+A small in-memory messaging service allowing one user to send a message to another. Messages are stored in a list.
+
+## Why this design
+This example demonstrates basic message sending without the complexity of persistence or message queues.
+
+## Pros
+- Clear separation of domain classes (`User`, `Message`).
+- Easy to extend with features like history or notifications.
+
+## Cons
+- Messages are not persisted or indexed.
+- No support for concurrent conversations.
+
+## Possible improvements
+- Store messages per user and allow retrieval by conversation.
+- Add persistence and asynchronous delivery.
+- Include features like read receipts.
+
+## Patterns and principles
+- Uses a simple service layer (`MessagingService`) to encapsulate operations.
+
+## High-level design
+`MessagingService.send` prints and stores a message object in memory. Clients can request the stored messages through `getMessages`.
+
+## Low-level design
+- `User` represents a chat participant.
+- `Message` captures sender, recipient and text.
+- `MessagingService` maintains the in-memory message store and exposes send/retrieve APIs.

--- a/src/main/java/systemdesign/parkinglot/README.md
+++ b/src/main/java/systemdesign/parkinglot/README.md
@@ -1,0 +1,31 @@
+# Parking Lot
+
+## Overview
+A simplified parking lot system consisting of parking spots managed by a service. Each spot has a type such as car or bike.
+
+## Why this design
+The intention is to show basic allocation of parking spots without external storage or complex rules.
+
+## Pros
+- Clear separation of responsibilities (`ParkingLot`, `ParkingService`).
+- Easy to extend with more spot types or pricing rules.
+
+## Cons
+- Does not handle concurrency or reservations.
+- Parking spots exist only in memory.
+
+## Possible improvements
+- Add persistence so the lot state survives restarts.
+- Support different pricing and billing strategies.
+- Implement search policies for the nearest available spot.
+
+## Patterns and principles
+- Demonstrates composition of objects to represent the domain.
+
+## High-level design
+`ParkingService` asks the `ParkingLot` for an available `ParkingSpot` of a given `VehicleType` and marks it as occupied.
+
+## Low-level design
+- `ParkingSpot` stores its type and occupancy state.
+- `ParkingLot` keeps a list of spots and can find one matching a type.
+- `ParkingService` is a thin layer that handles park and unpark requests.

--- a/src/main/java/systemdesign/ratelimiter/README.md
+++ b/src/main/java/systemdesign/ratelimiter/README.md
@@ -1,0 +1,29 @@
+# Rate Limiter
+
+## Overview
+Implements a fixed window rate limiting algorithm. It allows only a certain number of requests within a given time window.
+
+## Why this design
+Fixed window counters are easy to implement and sufficient for simple use cases where precision is not critical.
+
+## Pros
+- Very small memory footprint.
+- Simple synchronized logic.
+
+## Cons
+- Boundary effects at window rollover can allow bursts.
+- Not distributed across multiple instances.
+
+## Possible improvements
+- Use sliding window or token bucket algorithms for smoother limiting.
+- Share counters across servers using a distributed store.
+
+## Patterns and principles
+- Encapsulates rate limiting logic within a single `RateLimiter` class.
+
+## High-level design
+Each request invokes `allowRequest`. The class resets the counter when the window expires and returns whether the request is allowed.
+
+## Low-level design
+- Stores current window start time and request count.
+- `allowRequest` updates these fields in a thread-safe manner.

--- a/src/main/java/systemdesign/ridehailing/README.md
+++ b/src/main/java/systemdesign/ridehailing/README.md
@@ -1,0 +1,29 @@
+# Ride Hailing
+
+## Overview
+A tiny ride hailing example that matches a rider with a driver via a service call.
+
+## Why this design
+The classes illustrate the minimum pieces required to request a ride and assign it to a driver without location tracking or pricing.
+
+## Pros
+- Straightforward demonstration of service coordination.
+- Domain objects (`Rider`, `Driver`) are simple.
+
+## Cons
+- No search for nearby drivers or ride lifecycle.
+- No persistence or real-time updates.
+
+## Possible improvements
+- Integrate driver availability and location tracking.
+- Add pricing, trip management and payment handling.
+
+## Patterns and principles
+- Service layer (`RideService`) coordinates domain entities.
+
+## High-level design
+A rider and driver are provided to `RideService.requestRide`, which prints a match confirmation.
+
+## Low-level design
+- `Rider` and `Driver` store participant names.
+- `RideService` exposes a method to match a rider with a driver.

--- a/src/main/java/systemdesign/splitwise/README.md
+++ b/src/main/java/systemdesign/splitwise/README.md
@@ -1,0 +1,31 @@
+# Splitwise
+
+## Overview
+Models a simplified Splitwise-like expense sharing system. Balances are maintained in memory for each user.
+
+## Why this design
+The focus is on how expenses affect user balances rather than UI or persistence. Balances are kept in a map for quick demonstration.
+
+## Pros
+- Shows how expenses are divided and tracked per user.
+- Small number of classes with clear responsibilities.
+
+## Cons
+- No user authentication or groups.
+- Data is not persisted.
+
+## Possible improvements
+- Persist data so balances survive restarts.
+- Add support for splitting by percentages or unequal shares.
+- Provide reporting of who owes whom.
+
+## Patterns and principles
+- Keeps domain logic in `SplitwiseService` with plain data objects.
+
+## High-level design
+Users and their balances are stored in a map. When an expense is added, the map is updated for the payer and each share.
+
+## Low-level design
+- `User` represents a participant in the expense.
+- `Expense` contains the amount, payer and share breakdown.
+- `SplitwiseService` updates the `balanceMap` when new expenses are added.

--- a/src/main/java/systemdesign/urlshortener/README.md
+++ b/src/main/java/systemdesign/urlshortener/README.md
@@ -1,0 +1,32 @@
+# URL Shortener
+
+## Overview
+Provides a basic service to generate short codes for URLs and retrieve the original URL from the code.
+
+## Why this design
+Random codes combined with an in-memory repository keep the example concise while demonstrating the core workflow of shortening and expanding URLs.
+
+## Pros
+- Simple and self-contained.
+- Repository abstraction makes it easy to switch storage mechanisms.
+
+## Cons
+- Does not check for code collisions.
+- Data is not persisted across restarts.
+
+## Possible improvements
+- Implement collision detection or deterministic code generation.
+- Add analytics and expiration policies.
+- Persist mappings in a database or distributed cache.
+
+## Patterns and principles
+- Uses a repository to separate persistence from business logic.
+- Encapsulates functionality in a service class.
+
+## High-level design
+`UrlShortenerService.shorten` generates a random code and stores the mapping in `UrlRepository`. `getOriginalUrl` looks up the code.
+
+## Low-level design
+- `ShortUrl` is a data holder for code and original URL.
+- `UrlRepository` provides `save` and `find` methods for mappings.
+- `UrlShortenerService` orchestrates code generation and lookups.


### PR DESCRIPTION
## Summary
- add README for BookMyShow design
- add README for Food Delivery design
- add README for Log System design
- add README for LRU Cache design
- add README for Messaging design
- add README for Parking Lot design
- add README for Rate Limiter design
- add README for Ride Hailing design
- add README for Splitwise design
- add README for URL Shortener design

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a19c6183083269a9d2b896324c29c