### PR TITLE
Add thread and lock examples

### DIFF
--- a/src/main/java/threads/CallableExample.java
+++ b/src/main/java/threads/CallableExample.java
@@ -1,0 +1,23 @@
+package threads;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
+/**
+ * Demonstrates using {@link Callable} to produce a result from a thread.
+ */
+public class CallableExample implements Callable<String> {
+    @Override
+    public String call() {
+        return "Callable result";
+    }
+
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        CallableExample callable = new CallableExample();
+        FutureTask<String> future = new FutureTask<>(callable);
+        Thread thread = new Thread(future);
+        thread.start();
+        System.out.println(future.get());
+    }
+}

--- a/src/main/java/threads/ReadWriteLockDemo.java
+++ b/src/main/java/threads/ReadWriteLockDemo.java
@@ -1,0 +1,41 @@
+package threads;
+
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Illustrates using {@link java.util.concurrent.locks.ReadWriteLock} to allow multiple readers but exclusive writers.
+ */
+public class ReadWriteLockDemo {
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+    private int value = 0;
+
+    public void write(int newValue) {
+        rwLock.writeLock().lock();
+        try {
+            value = newValue;
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    public int read() {
+        rwLock.readLock().lock();
+        try {
+            return value;
+        } finally {
+            rwLock.readLock().unlock();
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        ReadWriteLockDemo demo = new ReadWriteLockDemo();
+
+        Thread writer = new Thread(() -> demo.write(42));
+        Thread reader = new Thread(() -> System.out.println("Read value: " + demo.read()));
+        writer.start();
+        reader.start();
+        writer.join();
+        reader.join();
+    }
+}

--- a/src/main/java/threads/ReentrantLockDemo.java
+++ b/src/main/java/threads/ReentrantLockDemo.java
@@ -1,0 +1,35 @@
+package threads;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Shows explicit locking using {@link ReentrantLock}.
+ */
+public class ReentrantLockDemo {
+    private final Lock lock = new ReentrantLock();
+    private int count = 0;
+
+    public void increment() {
+        lock.lock();
+        try {
+            count++;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        ReentrantLockDemo demo = new ReentrantLockDemo();
+        Runnable task = demo::increment;
+
+        Thread t1 = new Thread(task);
+        Thread t2 = new Thread(task);
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+
+        System.out.println("Final count: " + demo.count);
+    }
+}

--- a/src/main/java/threads/RunnableExample.java
+++ b/src/main/java/threads/RunnableExample.java
@@ -1,0 +1,16 @@
+package threads;
+
+/**
+ * Demonstrates creating a thread using the {@link Runnable} interface.
+ */
+public class RunnableExample implements Runnable {
+    @Override
+    public void run() {
+        System.out.println("Runnable task is running");
+    }
+
+    public static void main(String[] args) {
+        Thread t = new Thread(new RunnableExample());
+        t.start();
+    }
+}

--- a/src/main/java/threads/SemaphoreDemo.java
+++ b/src/main/java/threads/SemaphoreDemo.java
@@ -1,0 +1,39 @@
+package threads;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * Uses a {@link Semaphore} to limit concurrent access, behaving like a lock when only one permit is used.
+ */
+public class SemaphoreDemo {
+    private final Semaphore semaphore = new Semaphore(1);
+    private int count = 0;
+
+    public void increment() throws InterruptedException {
+        semaphore.acquire();
+        try {
+            count++;
+        } finally {
+            semaphore.release();
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        SemaphoreDemo demo = new SemaphoreDemo();
+        Runnable task = () -> {
+            try {
+                demo.increment();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        Thread t1 = new Thread(task);
+        Thread t2 = new Thread(task);
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        System.out.println("Final count: " + demo.count);
+    }
+}

--- a/src/main/java/threads/StampedLockDemo.java
+++ b/src/main/java/threads/StampedLockDemo.java
@@ -1,0 +1,40 @@
+package threads;
+
+import java.util.concurrent.locks.StampedLock;
+
+/**
+ * Example using {@link StampedLock} for optimistic reads.
+ */
+public class StampedLockDemo {
+    private final StampedLock lock = new StampedLock();
+    private int data = 0;
+
+    public void write(int value) {
+        long stamp = lock.writeLock();
+        try {
+            data = value;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
+
+    public int read() {
+        long stamp = lock.tryOptimisticRead();
+        int result = data;
+        if (!lock.validate(stamp)) {
+            stamp = lock.readLock();
+            try {
+                result = data;
+            } finally {
+                lock.unlockRead(stamp);
+            }
+        }
+        return result;
+    }
+
+    public static void main(String[] args) {
+        StampedLockDemo demo = new StampedLockDemo();
+        demo.write(5);
+        System.out.println("Read: " + demo.read());
+    }
+}

--- a/src/main/java/threads/SynchronizedDemo.java
+++ b/src/main/java/threads/SynchronizedDemo.java
@@ -1,0 +1,29 @@
+package threads;
+
+/**
+ * Uses the {@code synchronized} keyword which relies on an intrinsic lock.
+ */
+public class SynchronizedDemo {
+    private int count = 0;
+
+    /**
+     * Increments the counter in a thread-safe manner.
+     */
+    public synchronized void increment() {
+        count++;
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        SynchronizedDemo demo = new SynchronizedDemo();
+        Runnable task = demo::increment;
+
+        Thread t1 = new Thread(task);
+        Thread t2 = new Thread(task);
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+
+        System.out.println("Final count: " + demo.count);
+    }
+}

--- a/src/main/java/threads/ThreadExample.java
+++ b/src/main/java/threads/ThreadExample.java
@@ -1,0 +1,20 @@
+package threads;
+
+/**
+ * Demonstrates creating a thread by extending {@link Thread}.
+ */
+public class ThreadExample extends Thread {
+    public ThreadExample(String name) {
+        super(name);
+    }
+
+    @Override
+    public void run() {
+        System.out.println(getName() + " is running");
+    }
+
+    public static void main(String[] args) {
+        ThreadExample thread = new ThreadExample("MyThread");
+        thread.start();
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThreadExample` for extending `Thread`
- add `RunnableExample` for implementing `Runnable`
- add `CallableExample` for implementing `Callable`
- add lock demos: `SynchronizedDemo`, `ReentrantLockDemo`, `ReadWriteLockDemo`, `StampedLockDemo`, `SemaphoreDemo`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbfea0ce483268a9c93709a6c5bf8