### PR TITLE
Add comprehensive thread examples

### DIFF
--- a/src/main/java/threads/ExecutorServiceDemo.java
+++ b/src/main/java/threads/ExecutorServiceDemo.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -25,20 +26,25 @@ public class ExecutorServiceDemo {
 
         // Using a fixed thread pool
         ExecutorService fixedPool = Executors.newFixedThreadPool(2);
-        fixedPool.execute(runnableTask); // returns no result
-        Future<String> future = fixedPool.submit(callableTask); // returns a Future
-        System.out.println(future.get());
+        fixedPool.execute(runnableTask); // execute without expecting a result
+        Future<String> future = fixedPool.submit(callableTask); // submit returns a Future
+        System.out.println("Result from future: " + future.get());
         fixedPool.shutdown();
+        fixedPool.awaitTermination(1, TimeUnit.SECONDS);
+        System.out.println("isShutdown: " + fixedPool.isShutdown());
+        System.out.println("isTerminated: " + fixedPool.isTerminated());
 
         // Using a single thread executor
         ExecutorService singleThread = Executors.newSingleThreadExecutor();
         singleThread.submit(runnableTask);
-        singleThread.shutdown();
+        System.out.println("invokeAny result: " + singleThread.invokeAny(Arrays.asList(callableTask)));
+        singleThread.shutdownNow();
 
         // Using a cached thread pool
         ExecutorService cachedPool = Executors.newCachedThreadPool();
         cachedPool.submit(callableTask);
         cachedPool.shutdown();
+        cachedPool.awaitTermination(1, TimeUnit.SECONDS);
 
         // Using invokeAll with multiple callables
         ExecutorService pool = Executors.newFixedThreadPool(3);
@@ -51,11 +57,17 @@ public class ExecutorServiceDemo {
         for (Future<String> r : results) {
             System.out.println(r.get());
         }
+        System.out.println("invokeAny result: " + pool.invokeAny(tasks));
         pool.shutdown();
+        pool.awaitTermination(1, TimeUnit.SECONDS);
 
         // Using a scheduled executor service
         ScheduledExecutorService scheduled = Executors.newScheduledThreadPool(1);
-        scheduled.schedule(() -> System.out.println("Delayed task"), 1, TimeUnit.SECONDS);
+        ScheduledFuture<?> handle = scheduled.schedule(() -> System.out.println("Delayed task"),
+                1, TimeUnit.SECONDS);
+        scheduled.scheduleAtFixedRate(() -> System.out.println("Periodic task"), 0, 500, TimeUnit.MILLISECONDS);
+        handle.get();
         scheduled.shutdown();
+        scheduled.awaitTermination(1, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/threads/FutureDemo.java
+++ b/src/main/java/threads/FutureDemo.java
@@ -1,0 +1,50 @@
+package threads;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Demonstrates using {@link Future} and {@link FutureTask} to obtain results
+ * from asynchronous computations. The example shows common methods such as
+ * {@code get()}, {@code isDone()}, {@code cancel(boolean)} and
+ * {@code isCancelled()}.
+ */
+public class FutureDemo {
+
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        // Submit a Callable to obtain a Future representing the pending result
+        Callable<Integer> task = () -> {
+            TimeUnit.MILLISECONDS.sleep(100);
+            return 42;
+        };
+        Future<Integer> future = executor.submit(task);
+
+        System.out.println("Future done? " + future.isDone());
+        System.out.println("Result: " + future.get());
+        System.out.println("Future cancelled? " + future.isCancelled());
+
+        // Demonstrate Future.cancel()
+        Future<Integer> toCancel = executor.submit(task);
+        boolean cancelled = toCancel.cancel(true); // attempt to interrupt if running
+        System.out.println("Cancelled successfully? " + cancelled);
+        System.out.println("toCancel.isCancelled(): " + toCancel.isCancelled());
+
+        // Using FutureTask directly with a Thread
+        FutureTask<String> futureTask = new FutureTask<>(() -> {
+            TimeUnit.MILLISECONDS.sleep(50);
+            return "FutureTask result";
+        });
+        Thread t = new Thread(futureTask);
+        t.start();
+        System.out.println("FutureTask.get(): " + futureTask.get());
+
+        executor.shutdown();
+    }
+}

--- a/src/main/java/threads/README.md
+++ b/src/main/java/threads/README.md
@@ -1,11 +1,23 @@
 # Thread Utilities
 
-This package contains small demonstrations of core Java concurrency constructs.
+This package contains demonstrations of the most common Java concurrency constructs. Each class is heavily commented so you can understand what every method does.
 
-- **RunnableExample** – shows creating threads with `Runnable`.
-- **CallableExample** – demonstrates returning a value from a background task using `Callable` and `FutureTask`.
-- **ExecutorServiceDemo** – illustrates several variations of `ExecutorService` including fixed, cached and single-thread pools, as well as a scheduled executor service.
-- **ThreadExample** – extends the `Thread` class directly.
-- Additional classes show synchronization primitives such as locks and semaphores.
+## Basic thread creation
 
-These examples can be run individually using `java` or your IDE.
+* **ThreadExample** – minimal example of extending `Thread`.
+* **RunnableExample** – implements `Runnable` and runs the task in a `Thread`.
+* **ThreadMethodsDemo** – showcases `Thread` methods such as `setPriority`, `start`, `join`, `isAlive` and `interrupt`.
+
+## Returning results
+
+* **CallableExample** – uses `Callable` with `FutureTask` to return a value.
+* **FutureDemo** – explores operations on `Future` including `get`, `cancel` and running a `FutureTask` directly.
+
+## Executor frameworks
+
+* **ExecutorServiceDemo** – illustrates fixed, cached and single-thread pools, bulk operations like `invokeAll`/`invokeAny` and graceful shutdown. It also creates a scheduled executor for periodic tasks.
+* **ScheduledExecutorExample** – focuses exclusively on `ScheduledExecutorService`, showing delayed and periodic execution and how to cancel the returned `ScheduledFuture`.
+
+Additional classes demonstrate locks and other synchronization primitives such as semaphores and stamped locks.
+
+Run any example using `java` or from your IDE.

--- a/src/main/java/threads/ScheduledExecutorExample.java
+++ b/src/main/java/threads/ScheduledExecutorExample.java
@@ -1,0 +1,45 @@
+package threads;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Demonstrates {@link ScheduledExecutorService} methods for delayed and
+ * periodic execution. Each scheduling variant is shown along with cancelling
+ * the returned {@link ScheduledFuture}.
+ */
+public class ScheduledExecutorExample {
+
+    public static void main(String[] args) throws InterruptedException {
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+        // Single execution after a delay
+        Runnable oneTime = () -> System.out.println("Delayed task executed");
+        ScheduledFuture<?> single = scheduler.schedule(oneTime, 1, TimeUnit.SECONDS);
+
+        // Repeated execution at a fixed rate
+        Runnable rateTask = () -> System.out.println("fixedRate " + System.currentTimeMillis());
+        ScheduledFuture<?> rateFuture = scheduler.scheduleAtFixedRate(rateTask, 0, 500, TimeUnit.MILLISECONDS);
+
+        // Repeated execution with a fixed delay between completions
+        Runnable delayTask = () -> System.out.println("fixedDelay " + System.currentTimeMillis());
+        ScheduledFuture<?> delayFuture = scheduler.scheduleWithFixedDelay(delayTask, 0, 500, TimeUnit.MILLISECONDS);
+
+        // Let the tasks run for a short period
+        TimeUnit.SECONDS.sleep(2);
+
+        // Cancel periodic tasks
+        rateFuture.cancel(true);
+        delayFuture.cancel(true);
+
+        // Wait for the one-time task to complete
+        single.get();
+
+        // Shut down the scheduler gracefully
+        scheduler.shutdown();
+        scheduler.awaitTermination(1, TimeUnit.SECONDS);
+        System.out.println("Scheduler terminated: " + scheduler.isTerminated());
+    }
+}

--- a/src/main/java/threads/ThreadMethodsDemo.java
+++ b/src/main/java/threads/ThreadMethodsDemo.java
@@ -1,0 +1,47 @@
+package threads;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shows common lifecycle methods of {@link Thread} such as starting,
+ * joining and interrupting. Each worker prints messages so the order
+ * of operations is easy to follow.
+ */
+public class ThreadMethodsDemo {
+
+    private static class Worker extends Thread {
+        Worker(String name) {
+            super(name);           // sets the thread's name
+        }
+
+        @Override
+        public void run() {
+            try {
+                for (int i = 1; i <= 3; i++) {
+                    System.out.printf("[%s] iteration %d%n", getName(), i);
+                    TimeUnit.MILLISECONDS.sleep(200);
+                }
+            } catch (InterruptedException e) {
+                System.out.printf("[%s] interrupted%n", getName());
+            }
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        Thread t1 = new Worker("worker-1");
+        t1.setPriority(Thread.NORM_PRIORITY + 1);    // adjust priority
+
+        t1.start();          // start background work
+        System.out.println("t1 alive? " + t1.isAlive());
+
+        // Wait for completion of t1
+        t1.join();
+        System.out.println("t1 alive after join? " + t1.isAlive());
+
+        // Demonstrate interrupt
+        Thread t2 = new Worker("interruptible");
+        t2.start();
+        TimeUnit.MILLISECONDS.sleep(300);
+        t2.interrupt();
+    }
+}


### PR DESCRIPTION
## Summary
- add FutureDemo showing Future and FutureTask usage
- add ScheduledExecutorExample demonstrating ScheduledExecutorService
- add ThreadMethodsDemo covering common Thread APIs
- enhance ExecutorServiceDemo with more operations
- expand threads README with detailed explanations

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffe9626348326b150a4ffc3a14aa4