### PR TITLE
Configure surefire for JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,5 +28,18 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 
 </project>


### PR DESCRIPTION
## Summary
- configure Maven surefire plugin so JUnit 5 tests run automatically

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f538fc708326a8329a5219b9d182